### PR TITLE
Add context management and compression

### DIFF
--- a/lib/backend.ts
+++ b/lib/backend.ts
@@ -18,6 +18,8 @@ export interface Backend {
     onToken?: TokenCallback,
   ): Promise<Type>;
 
+  getContextLength(): Promise<number>;
+
   abort(): void;
 
   isAbortError(error: unknown): boolean;
@@ -33,6 +35,7 @@ export interface DefaultBackendSettings {
 
 export class DefaultBackend implements Backend {
   controller = new AbortController();
+  contextLength: number | null = null;
 
   // Can be overridden by subclasses to provide custom settings.
   getSettings(): DefaultBackendSettings {
@@ -169,6 +172,40 @@ export class DefaultBackend implements Backend {
     );
 
     return schema.parse(JSON.parse(response)) as Type;
+  }
+
+  async getContextLength(): Promise<number> {
+    if (this.contextLength !== null) {
+      return this.contextLength;
+    }
+    const client = this.getClient();
+    const modelName = this.getSettings().model;
+    const MAX_PAGES_TO_SEARCH = 3;
+    const FALLBACK_CONTEXT_LENGTH = 64000;
+    
+    let models = await client.models.list();
+    let pagesSearched = 0;
+    
+    while (pagesSearched < MAX_PAGES_TO_SEARCH) {
+      const found = models.data.find((m) => m.id === modelName) as { context_length?: number; } | undefined;
+      if (found && typeof found.context_length === "number") {
+        this.contextLength = found.context_length;
+        return found.context_length;
+      }
+      
+      pagesSearched++;
+      
+      // Try to get the next page if we haven't reached the limit
+      if (pagesSearched < MAX_PAGES_TO_SEARCH && models.hasNextPage()) {
+        models = await models.getNextPage();
+      } else {
+        break;
+      }
+    }
+    
+    // Fallback to default if not found
+    this.contextLength = FALLBACK_CONTEXT_LENGTH;
+    return this.contextLength;
   }
 
   abort(): void {

--- a/lib/context.ts
+++ b/lib/context.ts
@@ -1,0 +1,334 @@
+import { LocationChangeEvent, NarrationEvent, State, Event } from "./state";
+
+/**
+ * Represents the level of summarization applied to an event.
+ * One means it's an event level summary.
+ * Two means it's a scene level summary.
+ */
+enum SummaryLevel {
+  None = 0,
+  One = 1,
+  Two = 2
+}
+
+/**
+ * In order to make context fit within our budget, we go through a series of compression strategies.
+ * 
+ * We start by replacing the oldest events one by one and checking along the way if the context fits.
+ * We replace the oldest events with the summary level specified in the strategy until we reach the max percent of
+ * events we can compress with the current strategy. At the point we move on the to the next strategy.
+ * 
+ * Each subsequent strategy keeps the compression of previous strategies and
+ * either increases summary level of older events or applies the summary level to newer events.
+ */
+
+interface CompressionStrategy {
+  summaryLevel: SummaryLevel;
+  percent: number;
+}
+
+const COMPRESSION_STRATEGIES: CompressionStrategy[] = [
+  { summaryLevel: SummaryLevel.One, percent: .5 }, // up to 50% of the oldest events are at least SummaryLevel.One
+  { summaryLevel: SummaryLevel.Two, percent: .25 }, // up to 25% of the oldest events are at least SummaryLevel.Two
+  { summaryLevel: SummaryLevel.One, percent: .8 }, // up to 80% of the oldest events are at least SummaryLevel.One
+  { summaryLevel: SummaryLevel.Two, percent: .5 }, // up to 50% of the oldest events are at least SummaryLevel.Two
+  { summaryLevel: SummaryLevel.One, percent: 1 } // all events are least SummaryLevel.One
+];
+
+
+interface ContextUnit {
+  type : "location_change" | "narration";
+  summaryLevel: SummaryLevel;
+  text: string;
+  /** The number of tokens in this context unit at the current summary level */
+  tokenCount: number;
+  /** original event index (0 = oldest) covered by this unit, inclusive */
+  startEventIndex: number;
+  /** original event index (0 = oldest) covered by this unit, inclusive */
+  endEventIndex: number;
+}
+
+export function getContext(state: State, tokenBudget: number): string {
+  // we filter down to only narration and location change events,
+  // because the other event types like character_introduction are implied in the narration
+  const events = state.events.filter(event => event.type === "narration" || event.type === "location_change");
+  
+  if (events.length === 0) {
+    return "";
+  }
+
+  // Create initial context units
+  let contextUnits = createInitialContextUnits(events, state);
+  // if no compression is needed just return the context
+  if (isContextWithinBudget(contextUnits, tokenBudget)) return convertContextUnitsToText(contextUnits);
+
+  // Reverse to get oldest last prior to compression
+  // (since we'll be removing oldest events first and removing from the end is more efficient)
+  contextUnits.reverse();
+  
+  // Apply compression strategies until we fit within budget
+  for (const strategy of COMPRESSION_STRATEGIES) {
+    contextUnits = applyCompressionStrategy(contextUnits, strategy, events, tokenBudget);
+
+    if (isContextWithinBudget(contextUnits, tokenBudget)) {
+      break;
+    }
+  }
+  
+  // Reverse to get chronological order for output
+  contextUnits.reverse();
+  return convertContextUnitsToText(contextUnits);
+}
+
+/**
+ * Create the initial context without any compression.
+ * @param events events that should go in the context
+ * @param state current state
+ * @returns 
+ */
+function createInitialContextUnits(events: (NarrationEvent | LocationChangeEvent)[], state: State): ContextUnit[] {
+  const units: ContextUnit[] = [];
+
+  events.forEach((event, i) => {
+    if (event.type === "narration") {
+      const text = event.text;
+      units.push({
+        type: "narration",
+        summaryLevel: SummaryLevel.None,
+        text,
+        tokenCount: event.tokens ?? getApproximateTokenCount(text),
+        startEventIndex: i,
+        endEventIndex: i
+      });
+    } else if (event.type === "location_change") {
+      const text = convertLocationChangeEventToText(event, state);
+      units.push({
+        type: "location_change",
+        summaryLevel: SummaryLevel.None,
+        text,
+        tokenCount: getApproximateTokenCount(text),
+        startEventIndex: i,
+        endEventIndex: i
+      });
+    }
+  });
+
+  return units;
+}
+
+/**
+ * Apply a compression strategy to events in the context until the token budget is met or we've reached the maximum number of
+ * events to compress with the strategy.
+ * @param contextUnits The context units to compress.
+ * @param strategy The compression strategy to apply.
+ * @param events The original events.
+ * @param tokenBudget The token budget.
+ * @returns The compressed context units.
+ */
+function applyCompressionStrategy(
+  contextUnits: ContextUnit[], 
+  strategy: CompressionStrategy, 
+  events: (NarrationEvent | LocationChangeEvent)[], 
+  tokenBudget: number
+): ContextUnit[] {
+  const numTotalEvents = events.length;
+  const maxEventsToCompress = Math.floor(numTotalEvents * strategy.percent);
+  
+  // to calculate the percentage of events compressed, we'll store the index of the latest event compressed at
+  // the level required by the strategy.
+  // ex: if we have 100 events and latestEventCompressedIndex is 30, we've compressed 30% of the events
+  let latestEventCompressedIndex = 0;
+  
+  // Work from oldest to newest, applying the summary level that's needed
+  // until we reach the max percent of events we can compress with this strategy.
+  for (let i = contextUnits.length - 1; i >= 0 && latestEventCompressedIndex < maxEventsToCompress - 1; i--) {
+    if (contextUnits[i].summaryLevel < strategy.summaryLevel) {
+      if (strategy.summaryLevel === SummaryLevel.One) {
+        contextUnits[i] = compressToEventSummary(contextUnits[i], events);
+      } else if (strategy.summaryLevel === SummaryLevel.Two) {
+        const compressed = compressToSceneSummary(contextUnits, i, events);
+        if (compressed) {
+          // Replace the units that were compressed into a scene summary
+          contextUnits.splice(compressed.removeStart, compressed.removeCount, compressed.unit);
+          // Adjust index since we modified the array
+          i = compressed.removeStart;
+        }
+      }
+      // after applying a compression to an event, check if we're under budget
+      if (isContextWithinBudget(contextUnits, tokenBudget)) {
+        return contextUnits;
+      }
+    }
+    latestEventCompressedIndex = contextUnits[i].endEventIndex;
+  }
+  
+  return contextUnits;
+}
+
+/**
+ * Replace an event with its summary
+ */
+function compressToEventSummary(
+  unit: ContextUnit, 
+  events: (NarrationEvent | LocationChangeEvent)[], 
+): ContextUnit {
+  if (unit.type === "location_change") {
+    // Skip location change events for event-level summaries
+    return unit;
+  }
+  
+  const event = events[unit.startEventIndex] as NarrationEvent;
+  if (event.summary) {
+    return {
+      ...unit,
+      summaryLevel: SummaryLevel.One,
+      text: event.summary,
+      tokenCount: event.summaryTokens || getApproximateTokenCount(event.summary)
+    };
+  }
+  
+  // No summary available, return original
+  return unit;
+}
+
+/**
+ * Replace a series of events in a scene with the scene summary from the location change event that ends the scene.
+ * @param contextUnits All current context units.
+ * @param unitIndex The index of the unit to start compressing from (should be within the scene to compress).
+ * @param events The original events.
+ * @returns The compressed context unit, which index to remove from, and how many to remove.
+ */
+function compressToSceneSummary(
+  contextUnits: ContextUnit[], 
+  unitIndex: number, 
+  events: (NarrationEvent | LocationChangeEvent)[], 
+): { unit: ContextUnit; removeStart: number; removeCount: number } | null {
+  // Remember: contextUnits are in reverse chronological order (oldest at end)
+  // Find the location change that starts the scene containing this unit
+  let sceneStartIndex = -1;
+  
+  // Look backwards (towards older events) to find the scene start
+  for (let i = unitIndex; i < contextUnits.length; i++) {
+    if (contextUnits[i].type === "location_change") {
+      sceneStartIndex = i;
+      break;
+    }
+  }
+  
+  if (sceneStartIndex === -1) {
+    return null; // No scene start found
+  }
+  
+  // Find where this scene ends by looking forward (towards newer events)
+  let sceneEndIndex = unitIndex;
+  for (let i = unitIndex - 1; i >= 0; i--) {
+    if (contextUnits[i].type === "location_change") {
+      sceneEndIndex = i + 1; // Scene ends just before this location change
+      break;
+    }
+  }
+  
+  if (sceneEndIndex <= 0) {
+    sceneEndIndex = 0; // Scene goes to the newest events
+  }
+  
+  // Get the location change event that ends this scene (contains the scene summary)
+  // This is the location change AFTER the scene start in the original chronological order
+  const sceneStartEventIndex = contextUnits[sceneStartIndex].startEventIndex;
+  const nextLocationChangeEvent = findNextLocationChangeEvent(events, sceneStartEventIndex);
+  
+  if (!nextLocationChangeEvent || !nextLocationChangeEvent.summary) {
+    return null; // No scene summary available
+  }
+  
+  // Create the scene summary unit
+  const sceneSummaryUnit: ContextUnit = {
+    type: "location_change", 
+    summaryLevel: SummaryLevel.Two,
+    text: nextLocationChangeEvent.summary,
+    tokenCount: nextLocationChangeEvent.summaryTokens || getApproximateTokenCount(nextLocationChangeEvent.summary),
+    startEventIndex: contextUnits[sceneStartIndex].startEventIndex,
+    endEventIndex: contextUnits[sceneEndIndex].endEventIndex
+  };
+  
+  return {
+    unit: sceneSummaryUnit,
+    removeStart: sceneEndIndex,
+    removeCount: sceneStartIndex - sceneEndIndex + 1
+  };
+}
+
+/**
+ * Find the next location change event after a given index to start looking from.
+ * @param events The list of events to search.
+ * @param afterIndex The index to start searching from (exclusive).
+ * @returns The next location change event, or null if not found.
+ */
+function findNextLocationChangeEvent(
+  events: (NarrationEvent | LocationChangeEvent)[], 
+  afterIndex: number
+): LocationChangeEvent | null {
+  for (let i = afterIndex + 1; i < events.length; i++) {
+    if (events[i].type === "location_change") {
+      return events[i] as LocationChangeEvent;
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if the current context is within the token budget.
+ * @param contextUnits The context units to check.
+ * @param tokenBudget The token budget to compare against.
+ * @returns True if the context is within budget, false otherwise.
+ */
+function isContextWithinBudget(contextUnits: ContextUnit[], tokenBudget: number): boolean {
+  const totalTokens = contextUnits.reduce((sum: number, unit: ContextUnit) => sum + unit.tokenCount, 0);
+  return totalTokens <= tokenBudget;
+}
+
+/**
+ * Converts a location change event to text.
+ * @param event The location change event to convert.
+ * @param state The current state
+ * @returns A string describing the location change event.
+ */
+function convertLocationChangeEventToText(event: LocationChangeEvent, state: State): string {
+  const location = state.locations[event.locationIndex];
+  
+  return `-----
+
+LOCATION CHANGE
+
+${state.protagonist.name} is entering ${location.name}. ${location.description}
+
+The following characters are present at ${location.name}:
+
+${event.presentCharacterIndices
+  .map((index) => {
+    const character = state.characters[index];
+    return `${character.name}: ${character.biography}`;
+  })
+  .join("\n\n")}
+
+-----`;
+}
+
+/**
+ * Converts an array of context units representing the context to text.
+ * @param units The context units to convert.
+ * @returns A string representation of the context.
+ */
+function convertContextUnitsToText(units: ContextUnit[]): string {
+  return units.map(unit => unit.text).join("\n\n");
+}
+
+/**
+ * Estimates the number of tokens in a text string assuming 3.3 characters per token and rounding up.
+ * @param text The text to analyze.
+ * @returns The estimated token count.
+ */
+export function getApproximateTokenCount(text: string): number {
+  const numCharacters = text.length;
+  return Math.ceil(numCharacters / 3.3);
+};

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -56,6 +56,9 @@ export const NarrationEvent = z.object({
   text: Text.max(5000),
   locationIndex: Index,
   referencedCharacterIndices: Index.array(),
+  tokens: z.int().optional(),
+  summary: Text.max(2500).optional(),
+  summaryTokens: z.int().optional(),
 });
 
 export const CharacterIntroductionEvent = z.object({
@@ -67,6 +70,8 @@ export const LocationChangeEvent = z.object({
   type: z.literal("location_change"),
   locationIndex: Index,
   presentCharacterIndices: Index.array(),
+  summary: Text.max(5000).optional(),
+  summaryTokens: z.int().optional(),
 });
 
 export const Event = z.discriminatedUnion("type", [


### PR DESCRIPTION
Here's a first draft of my changes regarding context management and compression of context. These changes should mitigate issues with maxing out the context length of a model as the story progresses. To manage context we adopt a recursive summarization strategy where we first try replacing each individual events with a summary that strips out extraneous prose/dialogue. Then as the context fills up even more we replace entire scenes with a summary.

I've tested the summarization a bit and it generally seems to be working, but I've not extensively tested the context compression yet. I want to get some validation of my general approach before I spend time with more thorough testing.

### Summary of changes:
 - Update NarrationEvent to store tokens, summary, summary tokens.
 - Update LocationChangeEvent event to store tokens, summary, summary tokens.
 - Backends now need to implement a `getContextLength` method that allows us to get the max context size we can use with that backend. 
     - For DefaultBackend we try to use OpenAI compatible `/models` endpoint and fall back to a default (64k for now) context length if not found. We cache the value as an instance variable in DefaultBackend class so it doesn’t need to fetch each time.
 - After every narration event, we summarize the event. After every location change, we summarize all events from last location change to current location change.
 - We incorporate a token budget into prompts that require event history context, and we use the context generation algorithm described below to generate/compress the context.

### Context generation algorithm:
To make use of the summarizations, we have an algorithm that constructs the context given a token budget. There’s a few ways we could go about this. The simplest would be to progressively replace events in context with event summaries, and if we reach a point where we’ve replaced everything in context with an event summary, then start replacing the oldest scenes with their scene summaries. However, I think being able to keep the full text for newer events as much as possible will lead to higher quality. So I decided to come up with an algorithm that switches between using event summaries and scene summaries as we need more and more compression.

This is how it’s set up now:
At first it replaces the oldest events with their event summaries. Once 50% of events have been replaced by an event summary, then it goes back and starts replacing the oldest scenes with their scene summaries. Once 25% of oldest events have been replaced by their scene summaries, it switches back to event summaries again and starts replacing up to 80% of the oldest events with event summaries. Then switches to replacing with scene summaries and so on. If at any point the context fits in the token budget it stops and returns that context. All of these thresholds for switching between summary types can be easily modified. 


### Possible extensions to summarization:
 - Have separate model to handle summarization, maybe separate params to handle summarization.
 - For summarizing each scene (indicated by location change), if the scene was particularly massive it might have large context by itself.  So we could look into compression of context when generating scene summary.

There might be some edge cases where summarization might breakdown. Ex: if the user stays in the same location for so long that just that scene by itself maxes out the context window.